### PR TITLE
Fix the styling buttons in Chrome 65

### DIFF
--- a/vendor/assets/javascripts/redactor-rails/redactor.js
+++ b/vendor/assets/javascripts/redactor-rails/redactor.js
@@ -6167,6 +6167,12 @@
 					if (this.range.collapsed === false)
 					{
 						this.selection.setNodesMarker(this.range, endNode, false);
+
+						// Patched for Chrome 58, deleting text from selection + backspace
+						if (this.utils.browser('chrome'))
+						{
+							this.caret.set(startNode, 0, endNode, 0);
+						}
 					}
 					else
 					{
@@ -6287,6 +6293,8 @@
 					{
 						var node2 = this.selection.getMarker(2);
 						this.selection.setMarker(this.range, node2, false);
+
+						// Patched for Chrome 58, deleting text from selection + backspace
 						if (this.utils.browser('chrome'))
 						{
 								this.caret.set(node1, 0, node2, 0);


### PR DESCRIPTION
* Fix the styling buttons (e.g. bold, italics) in Chrome 65 - and
  probably older. Stack Overflow suggests Chrome 58.
* @dquilter fixed this originally in 8615985, however this behaviour is
  still broken in Sightsavers' ActiveAdmin.
* There's a StackOverflow issue that seems to match the problem we're
  experiencing, and the accepted answer uses the solution applied by DQ,
  however the comments suggest this is only a partial fix, ref:
  * https://stackoverflow.com/q/43674400/885540
  * https://stackoverflow.com/q/43674400/885540#comment75050875_43732840
* This applies the fix recommended by the comment, and that appears to
  have resolved the issue - though I'll be lying if I claim I know why
  `this.caret.set(node1, 0, node2, 0);` solves it.